### PR TITLE
Fix bullet2comma overeager prefix taking bug

### DIFF
--- a/lib/App/ListUtils.pm
+++ b/lib/App/ListUtils.pm
@@ -98,6 +98,8 @@ sub bullet2comma {
     require String::CommonPrefix;
     my $common_prefix = String::CommonPrefix::common_prefix(@lines);
 
+    $common_prefix =~ s/\w.*\z//;
+
     s/\A\Q$common_prefix// for @lines;
     join(", ", @lines) . "\n";
 }


### PR DESCRIPTION
Currently, bullet2comma uses get-common-prefix to get the bullet prefix. But this is too eager when there is a common text in the bullet items, e.g.:

    - foo
    - foobar

will result in:

    , bar

because "- foo " is assumed as the bullet prefix. This commit fixes this by only taking "- " as the bullet prefix.